### PR TITLE
WIP: RF Core peripheral mappings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "src/pieces/11",
     "src/pieces/12",
     "src/periph/ioc",
+    "src/periph/radio",
     "src/periph/gpio",
     "src/periph/sysctrl",
     "src/periph/tim",
@@ -49,6 +50,7 @@ gpio = ["drone-tisl-map-periph-gpio"]
 sysctrl = ["drone-tisl-map-periph-sysctrl"]
 tim = ["drone-tisl-map-periph-tim"]
 uart = ["drone-tisl-map-periph-uart"]
+radio = ["drone-tisl-map-periph-radio"]
 
 [dependencies.drone-core]
 version = "0.13.0"
@@ -87,3 +89,7 @@ version = "0.13.0"
 path = "src/periph/uart"
 optional = true
 
+[dependencies.drone-tisl-map-periph-radio]
+version = "0.13.0"
+path = "src/periph/radio"
+optional = true

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@ cortexm_core := 'cortexm4f_r0p1'
 tisl_mcu := 'cc2538'
 export DRONE_RUSTFLAGS := '--cfg cortexm_core="' + cortexm_core + '" ' + '--cfg tisl_mcu="' + tisl_mcu + '"'
 target := 'thumbv7em-none-eabihf'
-features := 'ioc gpio sysctrl tim uart'
+features := 'ioc gpio sysctrl tim uart radio'
 
 # Install dependencies
 deps:

--- a/src/periph/mod.rs
+++ b/src/periph/mod.rs
@@ -5,6 +5,8 @@ pub use drone_cortexm::map::periph::*;
 
 #[cfg(feature = "ioc")]
 pub extern crate drone_tisl_map_periph_ioc as ioc;
+#[cfg(feature = "radio")]
+pub extern crate drone_tisl_map_periph_radio as radio;
 #[cfg(feature = "gpio")]
 pub extern crate drone_tisl_map_periph_gpio as gpio;
 #[cfg(feature = "sysctrl")]

--- a/src/periph/radio/Cargo.toml
+++ b/src/periph/radio/Cargo.toml
@@ -1,0 +1,30 @@
+cargo-features = ["resolver"]
+
+[package]
+name = "drone-tisl-map-periph-radio"
+version = "0.13.0"
+authors = ["Valentine Valyaeff <valentine.valyaeff@gmail.com>"]
+edition = "2018"
+resolver = "2"
+repository = "https://github.com/drone-os/drone-tisl-map"
+homepage = "https://www.drone-os.com/"
+documentation = "https://api.drone-os.com/drone-tisal-map/0.12/drone_tisl_map_periph_sysctrl/"
+license = "MIT OR Apache-2.0"
+description = """
+TI(TM) peripheral mappings for Drone, an Embedded Operating System.
+"""
+
+[lib]
+path = "lib.rs"
+
+[dependencies.drone-core]
+version = "0.13.0"
+path = "../../../../drone-core"
+
+[dependencies.drone-cortexm]
+version = "0.13.0"
+path = "../../../../drone-cortexm"
+
+[dependencies.drone-tisl-map-pieces]
+version = "0.13.0"
+path = "../../pieces"

--- a/src/periph/radio/cc2538.rs
+++ b/src/periph/radio/cc2538.rs
@@ -1,0 +1,1169 @@
+//! Radio Core
+
+use drone_core::periph;
+use drone_cortexm::reg::marker::*;
+
+periph! {
+    /// Generic Radio peripheral variant.
+    pub trait RadioMap {}
+
+    /// Generic Radio peripheral.
+    pub struct RadioPeriph;
+
+    RFCORE_FFSM {
+        SRCRESMASK0 {
+            0x20 RwReg;
+            SRCRESMASK0 { RwRwRegFieldBits }
+        }
+        SRCRESMASK1 {
+            0x20 RwReg;
+            SRCRESMASK1 { RwRwRegFieldBits }
+        }
+        SRCRESMASK2 {
+            0x20 RwReg;
+            SRCRESMASK2 { RwRwRegFieldBits }
+        }
+        SRCRESINDEX {
+            0x20 RwReg;
+            SRCRESINDEX { RwRwRegFieldBits }
+        }
+        SRCEXTPENDEN0 {
+            0x20 RwReg;
+            SRCEXTPENDEN0 { RwRwRegFieldBits }
+        }
+        SRCEXTPENDEN1 {
+            0x20 RwReg;
+            SRCEXTPENDEN1 { RwRwRegFieldBits }
+        }
+        SRCEXTPENDEN2 {
+            0x20 RwReg;
+            SRCEXTPENDEN2 { RwRwRegFieldBits }
+        }
+        SRCSHORTPENDEN0 {
+            0x20 RwReg;
+            SRCSHORTPENDEN0 { RwRwRegFieldBits }
+        }
+        SRCSHORTPENDEN1 {
+            0x20 RwReg;
+            SRCSHORTPENDEN1 { RwRwRegFieldBits }
+        }
+        SRCSHORTPENDEN2 {
+            0x20 RwReg;
+            SRCSHORTPENDEN2 { RwRwRegFieldBits }
+        }
+        EXT_ADDR0 {
+            0x20 RwReg;
+            EXT_ADDR0 { RwRwRegFieldBits }
+        }
+        EXT_ADDR1 {
+            0x20 RwReg;
+            EXT_ADDR1 { RwRwRegFieldBits }
+        }
+        EXT_ADDR2 {
+            0x20 RwReg;
+            EXT_ADDR2 { RwRwRegFieldBits }
+        }
+        EXT_ADDR3 {
+            0x20 RwReg;
+            EXT_ADDR3 { RwRwRegFieldBits }
+        }
+        EXT_ADDR4 {
+            0x20 RwReg;
+            EXT_ADDR4 { RwRwRegFieldBits }
+        }
+        EXT_ADDR5 {
+            0x20 RwReg;
+            EXT_ADDR5 { RwRwRegFieldBits }
+        }
+        EXT_ADDR6 {
+            0x20 RwReg;
+            EXT_ADDR6 { RwRwRegFieldBits }
+        }
+        EXT_ADDR7 {
+            0x20 RwReg;
+            EXT_ADDR7 { RwRwRegFieldBits }
+        }
+        PAN_ID0 {
+            0x20 RwReg;
+            PAN_ID0 { RwRwRegFieldBits }
+        }
+        PAN_ID1 {
+            0x20 RwReg;
+            PAN_ID1 { RwRwRegFieldBits }
+        }
+        SHORT_ADDR0 {
+            0x20 RwReg;
+            SHORT_ADDR0 { RwRwRegFieldBits }
+        }
+        SHORT_ADDR1 {
+            0x20 RwReg;
+            SHORT_ADDR1 { RwRwRegFieldBits }
+        }
+    }
+
+    RFCORE_XREG {
+        FRMFILT0 {
+            0x20 RwReg;
+            FRAME_FILTER_EN { RwRwRegFieldBit }
+            PAN_COORDINATOR { RwRwRegFieldBit }
+            MAX_FRAME_VERSION { RwRwRegFieldBits }
+        }
+        FRMFILT1 {
+            0x20 RwReg;
+            MODIFY_FT_FILTER { RwRwRegFieldBits }
+            ACCEPT_FT_0_BEACON { RwRwRegFieldBit }
+            ACCEPT_FT_1_DATA { RwRwRegFieldBit }
+            ACCEPT_FT_2_ACK { RwRwRegFieldBit }
+            ACCEPT_FT_3_MAC_CMD { RwRwRegFieldBit }
+        }
+        SRCMATCH {
+            0x20 RwReg;
+            SRC_MATCH_EN { RwRwRegFieldBit }
+            AUTOPEND { RwRwRegFieldBit }
+            PEND_DATAREQ_ONLY { RwRwRegFieldBit }
+        }
+        SRCSHORTEN0 {
+            0x20 RwReg;
+            SHORT_ADDR_EN { RwRwRegFieldBits }
+        }
+        SRCSHORTEN1 {
+            0x20 RwReg;
+            SHORT_ADDR_EN { RwRwRegFieldBits }
+        }
+        SRCSHORTEN2 {
+            0x20 RwReg;
+            SHORT_ADDR_EN { RwRwRegFieldBits }
+        }
+        SRCEXTEN0 {
+            0x20 RwReg;
+            EXT_ADDR_EN { RwRwRegFieldBits }
+        }
+        SRCEXTEN1 {
+            0x20 RwReg;
+            EXT_ADDR_EN { RwRwRegFieldBits }
+        }
+        SRCEXTEN2 {
+            0x20 RwReg;
+            EXT_ADDR_EN { RwRwRegFieldBits }
+        }
+        FRMCTRL0 {
+            0x20 RwReg;
+            TX_MODE { RwRwRegFieldBits }
+            RX_MODE { RwRwRegFieldBits }
+            ENERGY_SCAN { RwRwRegFieldBit }
+            AUTOACK { RwRwRegFieldBit }
+            AUTOCRC { RwRwRegFieldBit }
+            APPEND_DATA_MODE { RwRwRegFieldBit }
+        }
+        FRMCTRL1 {
+            0x20 RwReg;
+            SET_RXENMASK_ON_TX { RwRwRegFieldBit }
+            IGNORE_TX_UNDERF { RwRwRegFieldBit }
+            PENDING_OR { RwRwRegFieldBit }
+        }
+        RXENABLE {
+            0x20 RoReg;
+            RXENMASK { RoRoRegFieldBits }
+        }
+        RXMASKSET {
+            0x20 RwReg;
+            RXENMASKSET { RwRwRegFieldBits }
+        }
+        RXMASKCLR {
+            0x20 RwReg;
+            RXENMASKCLR { RwRwRegFieldBits }
+        }
+        FREQTUNE {
+            0x20 RwReg;
+            XOSC32M_TUNE { RwRwRegFieldBits }
+        }
+        FREQCTRL {
+            0x20 RwReg;
+            FREQ { RwRwRegFieldBits }
+        }
+        TXPOWER {
+            0x20 RwReg;
+            PA_BIAS { RwRwRegFieldBits }
+            PA_POWER { RwRwRegFieldBits }
+        }
+        TXCTRL {
+            0x20 RwReg;
+            TXMIX_CURRENT { RwRwRegFieldBits }
+            DAC_DC { RwRwRegFieldBits }
+            DAC_CURR { RwRwRegFieldBits }
+        }
+        FSMSTAT0 {
+            0x20 RoReg;
+            FSM_FFCTRL_STATE { RoRoRegFieldBits }
+            CAL_RUNNING { RoRoRegFieldBit }
+            CAL_DONE { RoRoRegFieldBit }
+        }
+        FSMSTAT1 {
+            0x20 RoReg;
+            RX_ACTIVE { RoRoRegFieldBit }
+            TX_ACTIVE { RoRoRegFieldBit }
+            LOCK_STATUS { RoRoRegFieldBit }
+            SAMPLED_CCA { RoRoRegFieldBit }
+            CCA { RoRoRegFieldBit }
+            SFD { RoRoRegFieldBit }
+            FIFOP { RoRoRegFieldBit }
+            FIFO { RoRoRegFieldBit }
+        }
+        FIFOPCTRL {
+            0x20 RwReg;
+            FIFOP_THR { RwRwRegFieldBits }
+        }
+        FSMCTRL {
+            0x20 RwReg;
+            RX2RX_TIME_OFF { RwRwRegFieldBit }
+            SLOTTED_ACK { RwRwRegFieldBit }
+        }
+        CCACTRL0 {
+            0x20 RwReg;
+            CCA_THR { RwRwRegFieldBits }
+        }
+        CCACTRL1 {
+            0x20 RwReg;
+            CCA_HYST { RwRwRegFieldBits }
+            CCA_MODE { RwRwRegFieldBits }
+        }
+        RSSI {
+            0x20 RoReg;
+            RSSI_VAL { RoRoRegFieldBits }
+        }
+        RSSISTAT {
+            0x20 RoReg;
+            RSSI_VALID { RoRoRegFieldBit }
+        }
+        RXFIRST {
+            0x20 RoReg;
+            DATA { RoRoRegFieldBits }
+        }
+        RXFIFOCNT {
+            0x20 RoReg;
+            RXFIFOCNT { RoRoRegFieldBits }
+        }
+        TXFIFOCNT {
+            0x20 RoReg;
+            TXFIFOCNT { RoRoRegFieldBits }
+        }
+        RXFIRST_PTR {
+            0x20 RoReg;
+            RXFIRST_PTR { RoRoRegFieldBits }
+        }
+        RXLAST_PTR {
+            0x20 RoReg;
+            RXLAST_PTR { RoRoRegFieldBits }
+        }
+        RXP1_PTR {
+            0x20 RoReg;
+            RXP1_PTR { RoRoRegFieldBits }
+        }
+        TXFIRST_PTR {
+            0x20 RoReg;
+            TXFIRST_PTR { RoRoRegFieldBits }
+        }
+        TXLAST_PTR {
+            0x20 RoReg;
+            TXLAST_PTR { RoRoRegFieldBits }
+        }
+        RFIRQM0 {
+            0x20 RwReg;
+            RFIRQM { RwRwRegFieldBits }
+        }
+        RFIRQM1 {
+            0x20 RwReg;
+            RFIRQM { RwRwRegFieldBits }
+        }
+        RFERRM {
+            0x20 RwReg;
+            RFERRM { RwRwRegFieldBits }
+        }
+        RFRND {
+            0x20 RoReg;
+            IRND { RoRoRegFieldBit }
+            QRND { RoRoRegFieldBit }
+        }
+        MDMCTRL0 {
+            0x20 RwReg;
+            TX_FILTER { RwRwRegFieldBit }
+            PREAMBLE_LENGTH { RwRwRegFieldBits }
+            DEMOD_AVG_MODE { RwRwRegFieldBit }
+            DEM_NUM_ZEROS { RwRwRegFieldBits }
+        }
+        MDMCTRL1 {
+            0x20 RwReg;
+            CORR_THR { RwRwRegFieldBits }
+            CORR_THR_SFD { RwRwRegFieldBit }
+        }
+        FREQEST {
+            0x20 RoReg;
+            FREQEST { RoRoRegFieldBits }
+        }
+        RXCTRL {
+            0x20 RwReg;
+            MIX_CURRENT { RwRwRegFieldBits }
+            GBIAS_LNA_REF { RwRwRegFieldBits }
+            GBIAS_LNA2_REF { RwRwRegFieldBits }
+        }
+        FSCTRL {
+            0x20 RwReg;
+            LODIV_CURRENT { RwRwRegFieldBits }
+            LODIV_BUF_CURRENT_RX { RwRwRegFieldBits }
+            LODIV_BUF_CURRENT_TX { RwRwRegFieldBits }
+            PRE_CURRENT { RwRwRegFieldBits }
+        }
+        FSCAL0 {
+            0x20 RwReg;
+            BW_BOOST_MODE { RwRwRegFieldBits }
+            CHP_CURRENT { RwRwRegFieldBits }
+            CHP_DISABLE { RwRwRegFieldBit }
+            VCO_CURR_COMP_EN_OV { RwRwRegFieldBit }
+        }
+        FSCAL1 {
+            0x20 RwReg;
+            VCO_CURR { RwRwRegFieldBits }
+            VCO_CURR_CAL { RwRwRegFieldBits }
+            VCO_CURR_CAL_OE { RwRwRegFieldBit }
+        }
+        FSCAL2 {
+            0x20 RwReg;
+            VCO_CAPARR { RwRwRegFieldBits }
+            VCO_CAPARR_OE { RwRwRegFieldBit }
+        }
+        FSCAL3 {
+            0x20 RwReg;
+            VCO_CAPARR_CAL_CTRL { RwRwRegFieldBits }
+            VCO_VC_DAC { RwRwRegFieldBits }
+            VCO_DAC_EN_OV { RwRwRegFieldBit }
+        }
+        AGCCTRL0 {
+            0x20 RwReg;
+            AGC_DR_XTND_THR { RwRwRegFieldBits }
+            AGC_DR_XTND_EN { RwRwRegFieldBit }
+        }
+        AGCCTRL1 {
+            0x20 RwReg;
+            AGC_REF { RwRwRegFieldBits }
+        }
+        AGCCTRL2 {
+            0x20 RwReg;
+            LNA_CURRENT_OE { RwRwRegFieldBit }
+            LNA3_CURRENT { RwRwRegFieldBits }
+            LNA2_CURRENT { RwRwRegFieldBits }
+            LNA1_CURRENT { RwRwRegFieldBits }
+        }
+        AGCCTRL3 {
+            0x20 RwReg;
+            AAF_RP_OE { RwRwRegFieldBit }
+            AAF_RP { RwRwRegFieldBits }
+            AGC_WIN_SIZE { RwRwRegFieldBits }
+            AGC_SETTLE_WAIT { RwRwRegFieldBits }
+        }
+        ADCTEST0 {
+            0x20 RwReg;
+            ADC_DAC2_EN { RwRwRegFieldBit }
+            ADC_GM_ADJ { RwRwRegFieldBits }
+            ADC_QUANT_ADJ { RwRwRegFieldBits }
+            ADC_VREF_ADJ { RwRwRegFieldBits }
+        }
+        ADCTEST1 {
+            0x20 RwReg;
+            ADC_C3_ADJ { RwRwRegFieldBits }
+            ADC_C2_ADJ { RwRwRegFieldBits }
+            ADC_TEST_CTRL { RwRwRegFieldBits }
+        }
+        ADCTEST2 {
+            0x20 RwReg;
+            ADC_DAC_ROT { RwRwRegFieldBit }
+            ADC_FF_ADJ { RwRwRegFieldBits }
+            AAF_RS { RwRwRegFieldBits }
+            ADC_TEST_MODE { RwRwRegFieldBits }
+        }
+        MDMTEST0 {
+            0x20 RwReg;
+            DC_BLOCK_MODE { RwRwRegFieldBits }
+            DC_WIN_SIZE { RwRwRegFieldBits }
+            TX_TONE { RwRwRegFieldBits }
+        }
+        MDMTEST1 {
+            0x20 RwReg;
+            LOOPBACK_EN { RwRwRegFieldBit }
+            RFC_SNIFF_EN { RwRwRegFieldBit }
+            RAMP_AMP { RwRwRegFieldBit }
+            MOD_IF { RwRwRegFieldBit }
+            USEMIRROR_IF { RwRwRegFieldBit }
+        }
+        DACTEST0 {
+            0x20 RwReg;
+            DAC_Q_O { RwRwRegFieldBits }
+        }
+        DACTEST1 {
+            0x20 RwReg;
+            DAC_I_O { RwRwRegFieldBits }
+        }
+        DACTEST2 {
+            0x20 RwReg;
+            DAC_SRC { RwRwRegFieldBits }
+            DAC_CASC_CTRL { RwRwRegFieldBits }
+            DAC_DEM_EN { RwRwRegFieldBit }
+        }
+        ATEST {
+            0x20 RwReg;
+            ATEST_CTRL { RwRwRegFieldBits }
+        }
+        PTEST0 {
+            0x20 RwReg;
+            AAF_PD { RwRwRegFieldBit }
+            TXMIX_PD { RwRwRegFieldBit }
+            LNA_PD { RwRwRegFieldBits }
+            DAC_PD { RwRwRegFieldBit }
+            ADC_PD { RwRwRegFieldBit }
+            CHP_PD { RwRwRegFieldBit }
+            PRE_PD { RoRwRegFieldBit }
+        }
+        PTEST1 {
+            0x20 RwReg;
+            LODIV_PD { RwRwRegFieldBit }
+            VCO_PD { RwRwRegFieldBit }
+            PA_PD { RwRwRegFieldBit }
+            PD_OVERRIDE { RwRwRegFieldBit }
+        }
+        CSPPROG_0 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_1 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_2 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_3 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_4 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_5 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_6 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_7 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_8 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_9 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_10 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_11 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_12 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_13 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_14 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_15 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_16 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_17 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_18 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_19 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_20 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_21 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_22 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPPROG_23 {
+            0x20 RoReg;
+            CSP_INSTR { RoRoRegFieldBits }
+        }
+        CSPCTRL  {
+            0x20 RwReg;
+            MCU_CTRL { RwRwRegFieldBit}
+        }
+        CSPSTAT {
+            0x20 RoReg;
+            CSP_PC { RoRoRegFieldBits }
+            CSP_RUNNING { RoRoRegFieldBit }
+        }
+        CSPX {
+            0x20 RoReg;
+            CSPX { RoRoRegFieldBits }
+        }
+        CSPY {
+            0x20 RoReg;
+            CSPY { RoRoRegFieldBits }
+        }
+        CSPZ {
+            0x20 RoReg;
+            CSPZ { RoRoRegFieldBits }
+        }
+        CSPT {
+            0x20 RoReg;
+            CSPT { RoRoRegFieldBits }
+        }
+        RFC_OBS_CTRL0 {
+            0x20 RwReg;
+            RFC_OBS_MUX0 { RwRwRegFieldBits }
+            RFC_OBS_POL0 { RwRwRegFieldBit }
+        }
+        RFC_OBS_CTRL1 {
+            0x20 RwReg;
+            RFC_OBS_MUX1 { RwRwRegFieldBits }
+            RFC_OBS_POL1 { RwRwRegFieldBit }
+        }
+        RFC_OBS_CTRL2 {
+            0x20 RwReg;
+            RFC_OBS_MUX2 { RwRwRegFieldBits }
+            RFC_OBS_POL2 { RwRwRegFieldBit }
+        }
+        TXFILTCFG {
+            0x20 RwReg;
+            FC { RwRwRegFieldBits }
+        }
+    }
+}
+
+#[allow(unused_macros)]
+macro_rules! map_radio {
+    (
+        $radio_macro_doc:expr,
+        $radio_macro:ident,
+        $radio_ty_doc:expr,
+        $radio_ty:ident,
+        $radio:ident,
+    ) => {
+        periph::map! {
+            #[doc = $radio_macro_doc]
+            pub macro $radio_macro;
+
+            #[doc = $radio_ty_doc]
+            pub struct $radio_ty;
+
+            impl RadioMap for $radio_ty {}
+
+            drone_tisl_map_pieces::reg;
+            crate;
+
+            RFCORE_FFSM {
+                $radio;
+                SRCRESMASK0 {
+                    SRCRESMASK0;
+                    SRCRESMASK0 { SRCRESMASK0 }
+                }
+                SRCRESMASK1 {
+                    SRCRESMASK1;
+                    SRCRESMASK1 { SRCRESMASK1 }
+                }
+                SRCRESMASK2 {
+                    SRCRESMASK2;
+                    SRCRESMASK2 { SRCRESMASK2 }
+                }
+                SRCRESINDEX {
+                    SRCRESINDEX;
+                    SRCRESINDEX { SRCRESINDEX }
+                }
+                SRCEXTPENDEN0 {
+                    SRCEXTPENDEN0;
+                    SRCEXTPENDEN0 { SRCEXTPENDEN0 }
+                }
+                SRCEXTPENDEN1 {
+                    SRCEXTPENDEN1;
+                    SRCEXTPENDEN1 { SRCEXTPENDEN1 }
+                }
+                SRCEXTPENDEN2 {
+                    SRCEXTPENDEN2;
+                    SRCEXTPENDEN2 { SRCEXTPENDEN2 }
+                }
+                SRCSHORTPENDEN0 {
+                    SRCSHORTPENDEN0;
+                    SRCSHORTPENDEN0 { SRCSHORTPENDEN0 }
+                }
+                SRCSHORTPENDEN1 {
+                    SRCSHORTPENDEN1;
+                    SRCSHORTPENDEN1 { SRCSHORTPENDEN1 }
+                }
+                SRCSHORTPENDEN2 {
+                    SRCSHORTPENDEN2;
+                    SRCSHORTPENDEN2 { SRCSHORTPENDEN2 }
+                }
+                EXT_ADDR0 {
+                    EXT_ADDR0;
+                    EXT_ADDR0 { EXT_ADDR0 }
+                }
+                EXT_ADDR1 {
+                    EXT_ADDR1;
+                    EXT_ADDR1 { EXT_ADDR1 }
+                }
+                EXT_ADDR2 {
+                    EXT_ADDR2;
+                    EXT_ADDR2 { EXT_ADDR2 }
+                }
+                EXT_ADDR3 {
+                    EXT_ADDR3;
+                    EXT_ADDR3 { EXT_ADDR3 }
+                }
+                EXT_ADDR4 {
+                    EXT_ADDR4;
+                    EXT_ADDR4 { EXT_ADDR4 }
+                }
+                EXT_ADDR5 {
+                    EXT_ADDR5;
+                    EXT_ADDR5 { EXT_ADDR5 }
+                }
+                EXT_ADDR6 {
+                    EXT_ADDR6;
+                    EXT_ADDR6 { EXT_ADDR6 }
+                }
+                EXT_ADDR7 {
+                    EXT_ADDR7;
+                    EXT_ADDR7 { EXT_ADDR7 }
+                }
+                PAN_ID0 {
+                    PAN_ID0;
+                    PAN_ID0 { PAN_ID0 }
+                }
+                PAN_ID1 {
+                    PAN_ID1;
+                    PAN_ID1 { PAN_ID1 }
+                }
+                SHORT_ADDR0 {
+                    SHORT_ADDR0;
+                    SHORT_ADDR0 { SHORT_ADDR0 }
+                }
+                SHORT_ADDR1 {
+                    SHORT_ADDR1;
+                    SHORT_ADDR1 { SHORT_ADDR1 }
+                }
+            }
+
+            RFCORE_XREG {
+                RFCORE_XREG;
+                FRMFILT0 {
+                    FRMFILT0;
+                    FRAME_FILTER_EN { FRAME_FILTER_EN }
+                    PAN_COORDINATOR { PAN_COORDINATOR }
+                    MAX_FRAME_VERSION { MAX_FRAME_VERSION }
+                }
+                FRMFILT1 {
+                    FRMFILT1;
+                    MODIFY_FT_FILTER { MODIFY_FT_FILTER }
+                    ACCEPT_FT_0_BEACON { ACCEPT_FT_0_BEACON }
+                    ACCEPT_FT_1_DATA { ACCEPT_FT_1_DATA }
+                    ACCEPT_FT_2_ACK { ACCEPT_FT_2_ACK }
+                    ACCEPT_FT_3_MAC_CMD { ACCEPT_FT_3_MAC_CMD }
+                }
+                SRCMATCH {
+                    SRCMATCH;
+                    SRC_MATCH_EN { SRC_MATCH_EN }
+                    AUTOPEND { AUTOPEND }
+                    PEND_DATAREQ_ONLY { PEND_DATAREQ_ONLY }
+                }
+                SRCSHORTEN0 {
+                    SRCSHORTEN0;
+                    SHORT_ADDR_EN { SHORT_ADDR_EN }
+                }
+                SRCSHORTEN1 {
+                    SRCSHORTEN1;
+                    SHORT_ADDR_EN { SHORT_ADDR_EN }
+                }
+                SRCSHORTEN2 {
+                    SRCSHORTEN2;
+                    SHORT_ADDR_EN { SHORT_ADDR_EN }
+                }
+                SRCEXTEN0 {
+                    SRCEXTEN0;
+                    EXT_ADDR_EN { EXT_ADDR_EN }
+                }
+                SRCEXTEN1 {
+                    SRCEXTEN1;
+                    EXT_ADDR_EN { EXT_ADDR_EN }
+                }
+                SRCEXTEN2 {
+                    SRCEXTEN2;
+                    EXT_ADDR_EN { EXT_ADDR_EN }
+                }
+                FRMCTRL0 {
+                    FRMCTRL0;
+                    TX_MODE { TX_MODE }
+                    RX_MODE { RX_MODE }
+                    ENERGY_SCAN { ENERGY_SCAN }
+                    AUTOACK { AUTOACK }
+                    AUTOCRC { AUTOCRC }
+                    APPEND_DATA_MODE { APPEND_DATA_MODE }
+                }
+                FRMCTRL1 {
+                    FRMCTRL1;
+                    SET_RXENMASK_ON_TX { SET_RXENMASK_ON_TX }
+                    IGNORE_TX_UNDERF { IGNORE_TX_UNDERF }
+                    PENDING_OR { PENDING_OR }
+                }
+                RXENABLE {
+                    RXENABLE;
+                    RXENMASK { RXENMASK }
+                }
+                RXMASKSET {
+                    RXMASKSET;
+                    RXENMASKSET { RXENMASKSET }
+                }
+                RXMASKCLR {
+                    RXMASKCLR;
+                    RXENMASKCLR { RXENMASKCLR }
+                }
+                FREQTUNE {
+                    FREQTUNE;
+                    XOSC32M_TUNE { XOSC32M_TUNE }
+                }
+                FREQCTRL {
+                    FREQCTRL;
+                    FREQ { FREQ }
+                }
+                TXPOWER {
+                    TXPOWER;
+                    PA_BIAS { PA_BIAS }
+                    PA_POWER { PA_POWER }
+                }
+                TXCTRL {
+                    TXCTRL;
+                    TXMIX_CURRENT { TXMIX_CURRENT }
+                    DAC_DC { DAC_DC }
+                    DAC_CURR { DAC_CURR }
+                }
+                FSMSTAT0 {
+                    FSMSTAT0;
+                    FSM_FFCTRL_STATE { FSM_FFCTRL_STATE }
+                    CAL_RUNNING { CAL_RUNNING }
+                    CAL_DONE { CAL_DONE }
+                }
+                FSMSTAT1 {
+                    FSMSTAT1;
+                    RX_ACTIVE { RX_ACTIVE }
+                    TX_ACTIVE { TX_ACTIVE }
+                    LOCK_STATUS { LOCK_STATUS }
+                    SAMPLED_CCA { SAMPLED_CCA }
+                    CCA { CCA }
+                    SFD { SFD }
+                    FIFOP { FIFOP }
+                    FIFO { FIFO }
+                }
+                FIFOPCTRL {
+                    FIFOPCTRL;
+                    FIFOP_THR { FIFOP_THR }
+                }
+                FSMCTRL {
+                    FSMCTRL;
+                    RX2RX_TIME_OFF { RX2RX_TIME_OFF }
+                    SLOTTED_ACK { SLOTTED_ACK }
+                }
+                CCACTRL0 {
+                    CCACTRL0;
+                    CCA_THR { CCA_THR }
+                }
+                CCACTRL1 {
+                    CCACTRL1;
+                    CCA_HYST { CCA_HYST }
+                    CCA_MODE { CCA_MODE }
+                }
+                RSSI {
+                    RSSI;
+                    RSSI_VAL { RSSI_VAL }
+                }
+                RSSISTAT {
+                    RSSISTAT;
+                    RSSI_VALID { RSSI_VALID }
+                }
+                RXFIRST {
+                    RXFIRST;
+                    DATA { DATA }
+                }
+                RXFIFOCNT {
+                    RXFIFOCNT;
+                    RXFIFOCNT { RXFIFOCNT }
+                }
+                TXFIFOCNT {
+                    TXFIFOCNT;
+                    TXFIFOCNT { TXFIFOCNT }
+                }
+                RXFIRST_PTR {
+                    RXFIRST_PTR;
+                    RXFIRST_PTR { RXFIRST_PTR }
+                }
+                RXLAST_PTR {
+                    RXLAST_PTR;
+                    RXLAST_PTR { RXLAST_PTR }
+                }
+                RXP1_PTR {
+                    RXP1_PTR;
+                    RXP1_PTR { RXP1_PTR }
+                }
+                TXFIRST_PTR {
+                    TXFIRST_PTR;
+                    TXFIRST_PTR { TXFIRST_PTR }
+                }
+                TXLAST_PTR {
+                    TXLAST_PTR;
+                    TXLAST_PTR { TXLAST_PTR }
+                }
+                RFIRQM0 {
+                    RFIRQM0;
+                    RFIRQM { RFIRQM }
+                }
+                RFIRQM1 {
+                    RFIRQM1;
+                    RFIRQM { RFIRQM }
+                }
+                RFERRM {
+                    RFERRM;
+                    RFERRM { RFERRM }
+                }
+                RFRND {
+                    RFRND;
+                    IRND { IRND }
+                    QRND { QRND }
+                }
+                MDMCTRL0 {
+                    MDMCTRL0;
+                    TX_FILTER { TX_FILTER }
+                    PREAMBLE_LENGTH { PREAMBLE_LENGTH }
+                    DEMOD_AVG_MODE { DEMOD_AVG_MODE }
+                    DEM_NUM_ZEROS { DEM_NUM_ZEROS }
+                }
+                MDMCTRL1 {
+                    MDMCTRL1;
+                    CORR_THR { CORR_THR }
+                    CORR_THR_SFD { CORR_THR_SFD }
+                }
+                FREQEST {
+                    FREQEST;
+                    FREQEST { FREQEST }
+                }
+                RXCTRL {
+                    RXCTRL;
+                    MIX_CURRENT { MIX_CURRENT }
+                    GBIAS_LNA_REF { GBIAS_LNA_REF }
+                    GBIAS_LNA2_REF { GBIAS_LNA2_REF }
+                }
+                FSCTRL {
+                    FSCTRL;
+                    LODIV_CURRENT { LODIV_CURRENT }
+                    LODIV_BUF_CURRENT_RX { LODIV_BUF_CURRENT_RX }
+                    LODIV_BUF_CURRENT_TX { LODIV_BUF_CURRENT_TX }
+                    PRE_CURRENT { PRE_CURRENT }
+                }
+                FSCAL0 {
+                    FSCAL0;
+                    BW_BOOST_MODE { BW_BOOST_MODE }
+                    CHP_CURRENT { CHP_CURRENT }
+                    CHP_DISABLE { CHP_DISABLE }
+                    VCO_CURR_COMP_EN_OV { VCO_CURR_COMP_EN_OV }
+                }
+                FSCAL1 {
+                    FSCAL1;
+                    VCO_CURR { VCO_CURR }
+                    VCO_CURR_CAL { VCO_CURR_CAL }
+                    VCO_CURR_CAL_OE { VCO_CURR_CAL_OE }
+                }
+                FSCAL2 {
+                    FSCAL2;
+                    VCO_CAPARR { VCO_CAPARR }
+                    VCO_CAPARR_OE { VCO_CAPARR_OE }
+                }
+                FSCAL3 {
+                    FSCAL3;
+                    VCO_CAPARR_CAL_CTRL { VCO_CAPARR_CAL_CTRL }
+                    VCO_VC_DAC { VCO_VC_DAC }
+                    VCO_DAC_EN_OV { VCO_DAC_EN_OV }
+                }
+                AGCCTRL0 {
+                    AGCCTRL0;
+                    AGC_DR_XTND_THR { AGC_DR_XTND_THR }
+                    AGC_DR_XTND_EN { AGC_DR_XTND_EN }
+                }
+                AGCCTRL1 {
+                    AGCCTRL1;
+                    AGC_REF { AGC_REF }
+                }
+                AGCCTRL2 {
+                    AGCCTRL2;
+                    LNA_CURRENT_OE { LNA_CURRENT_OE }
+                    LNA3_CURRENT { LNA3_CURRENT }
+                    LNA2_CURRENT { LNA2_CURRENT }
+                    LNA1_CURRENT { LNA1_CURRENT }
+                }
+                AGCCTRL3 {
+                    AGCCTRL3;
+                    AAF_RP_OE { AAF_RP_OE }
+                    AAF_RP { AAF_RP }
+                    AGC_WIN_SIZE { AGC_WIN_SIZE }
+                    AGC_SETTLE_WAIT { AGC_SETTLE_WAIT }
+                }
+                ADCTEST0 {
+                    ADCTEST0;
+                    ADC_DAC2_EN { ADC_DAC2_EN }
+                    ADC_GM_ADJ { ADC_GM_ADJ }
+                    ADC_QUANT_ADJ { ADC_QUANT_ADJ }
+                    ADC_VREF_ADJ { ADC_VREF_ADJ }
+                }
+                ADCTEST1 {
+                    ADCTEST1;
+                    ADC_C3_ADJ { ADC_C3_ADJ }
+                    ADC_C2_ADJ { ADC_C2_ADJ }
+                    ADC_TEST_CTRL { ADC_TEST_CTRL }
+                }
+                ADCTEST2 {
+                    ADCTEST2;
+                    ADC_DAC_ROT { ADC_DAC_ROT }
+                    ADC_FF_ADJ { ADC_FF_ADJ }
+                    AAF_RS { AAF_RS }
+                    ADC_TEST_MODE { ADC_TEST_MODE }
+                }
+                MDMTEST0 {
+                    MDMTEST0;
+                    DC_BLOCK_MODE { DC_BLOCK_MODE }
+                    DC_WIN_SIZE { DC_WIN_SIZE }
+                    TX_TONE { TX_TONE }
+                }
+                MDMTEST1 {
+                    MDMTEST1;
+                    LOOPBACK_EN { LOOPBACK_EN }
+                    RFC_SNIFF_EN { RFC_SNIFF_EN }
+                    RAMP_AMP { RAMP_AMP }
+                    MOD_IF { MOD_IF }
+                    USEMIRROR_IF { USEMIRROR_IF }
+                }
+                DACTEST0 {
+                    DACTEST0;
+                    DAC_Q_O { DAC_Q_O }
+                }
+                DACTEST1 {
+                    DACTEST1;
+                    DAC_I_O { DAC_I_O }
+                }
+                DACTEST2 {
+                    DACTEST2;
+                    DAC_SRC { DAC_SRC }
+                    DAC_CASC_CTRL { DAC_CASC_CTRL }
+                    DAC_DEM_EN { DAC_DEM_EN }
+                }
+                ATEST {
+                    ATEST;
+                    ATEST_CTRL { ATEST_CTRL }
+                }
+                PTEST0 {
+                    PTEST0;
+                    AAF_PD { AAF_PD }
+                    TXMIX_PD { TXMIX_PD }
+                    LNA_PD { LNA_PD }
+                    DAC_PD { DAC_PD }
+                    ADC_PD { ADC_PD }
+                    CHP_PD { CHP_PD }
+                    PRE_PD { PRE_PD }
+                }
+                PTEST1 {
+                    PTEST1;
+                    LODIV_PD { LODIV_PD }
+                    VCO_PD { VCO_PD }
+                    PA_PD { PA_PD }
+                    PD_OVERRIDE { PD_OVERRIDE }
+                }
+                CSPPROG_0 {
+                    CSPPROG_0;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_1 {
+                    CSPPROG_1;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_2 {
+                    CSPPROG_2;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_3 {
+                    CSPPROG_3;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_4 {
+                    CSPPROG_4;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_5 {
+                    CSPPROG_5;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_6 {
+                    CSPPROG_6;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_7 {
+                    CSPPROG_7;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_8 {
+                    CSPPROG_8;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_9 {
+                    CSPPROG_9;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_10 {
+                    CSPPROG_10;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_11 {
+                    CSPPROG_11;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_12 {
+                    CSPPROG_12;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_13 {
+                    CSPPROG_13;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_14 {
+                    CSPPROG_14;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_15 {
+                    CSPPROG_15;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_16 {
+                    CSPPROG_16;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_17 {
+                    CSPPROG_17;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_18 {
+                    CSPPROG_18;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_19 {
+                    CSPPROG_19;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_20 {
+                    CSPPROG_20;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_21 {
+                    CSPPROG_21;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_22 {
+                    CSPPROG_22;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPPROG_23 {
+                    CSPPROG_23;
+                    CSP_INSTR { CSP_INSTR }
+                }
+                CSPCTRL  {
+                    CSPCTRL;
+                    MCU_CTRL { MCU_CTRL }
+                }
+                CSPSTAT {
+                    CSPSTAT;
+                    CSP_PC { CSP_PC }
+                    CSP_RUNNING { CSP_RUNNING }
+                }
+                CSPX {
+                    CSPX;
+                    CSPX { CSPX }
+                }
+                CSPY {
+                    CSPY;
+                    CSPY { CSPY }
+                }
+                CSPZ {
+                    CSPZ;
+                    CSPZ { CSPZ }
+                }
+                CSPT {
+                    CSPT;
+                    CSPT { CSPT }
+                }
+                RFC_OBS_CTRL0 {
+                    RFC_OBS_CTRL0;
+                    RFC_OBS_MUX0 { RFC_OBS_MUX0 }
+                    RFC_OBS_POL0 { RFC_OBS_POL0 }
+                }
+                RFC_OBS_CTRL1 {
+                    RFC_OBS_CTRL1;
+                    RFC_OBS_MUX1 { RFC_OBS_MUX1 }
+                    RFC_OBS_POL1 { RFC_OBS_POL1 }
+                }
+                RFC_OBS_CTRL2 {
+                    RFC_OBS_CTRL2;
+                    RFC_OBS_MUX2 { RFC_OBS_MUX2 }
+                    RFC_OBS_POL2 { RFC_OBS_POL2 }
+                }
+                TXFILTCFG {
+                    TXFILTCFG;
+                    FC { FC }
+                }
+            }
+        }
+    };
+}
+
+#[cfg(tisl_mcu = "cc2538")]
+map_radio! {
+    "Extracts Radio Register tokens.",
+    periph_radio,
+    "Radio peipheral variant.",
+    RfCoreFfsm,
+    RFCORE_FFSM,
+}

--- a/src/periph/radio/lib.rs
+++ b/src/periph/radio/lib.rs
@@ -1,0 +1,11 @@
+//! Radio Core
+
+#![feature(proc_macro_hygiene)]
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::type_repetition_in_bounds, clippy::wildcard_imports)]
+#![no_std]
+
+pub mod cc2538;
+
+pub use self::cc2538::*;

--- a/svd_files/CC2538.svd
+++ b/svd_files/CC2538.svd
@@ -7013,13 +7013,6 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>FCF_RESERVED_MASK</name>
-              <description>Used for filtering on the reserved part of the frame control field (FCF) FCF_RESERVED_MASK[2:0] is ANDed with FCF[9:7]. If the result is nonzero and frame filtering is enabled, the frame is rejected.</description>
-              <bitOffset>4</bitOffset>
-              <bitWidth>3</bitWidth>
-              <access>read-write</access>
-            </field>
-            <field>
               <name>MAX_FRAME_VERSION</name>
               <description>Used for filtering on the frame version field of the frame control field (FCF) If FCF[13:12] (the frame version subfield) is higher than MAX_FRAME_VERSION[1:0] and frame filtering is enabled, the frame is rejected. </description>
               <bitOffset>2</bitOffset>
@@ -7049,13 +7042,6 @@
           <size>32</size>
           <resetValue>0</resetValue>
           <fields>
-            <field>
-              <name>ACCEPT_FT_4TO7_RESERVED</name>
-              <description>Defines whether reserved frames are accepted or not. Reserved frames have frame type = 100, 101, 110, or 111. 0: Reject 1: Accept </description>
-              <bitOffset>7</bitOffset>
-              <bitWidth>1</bitWidth>
-              <access>read-write</access>
-            </field>
             <field>
               <name>ACCEPT_FT_3_MAC_CMD</name>
               <description>Defines whether MAC command frames are accepted or not. MAC command frames have frame type = 011. 0: Reject 1: Accept</description>
@@ -7089,13 +7075,6 @@
               <description>These bits are used to modify the frame type field of a received frame before frame type filtering is performed. The modification does not influence the frame that is written to the RX FIFO. 00: Leave the frame type as it is. 01: Invert MSB of the frame type. 10: Set MSB of the frame type to 0. 11: Set MSB of the frame type to 1. </description>
               <bitOffset>1</bitOffset>
               <bitWidth>2</bitWidth>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>FRM_RESERVED</name>
-              <description>Reserved. Always write 0.</description>
-              <bitOffset>0</bitOffset>
-              <bitWidth>1</bitWidth>
               <access>read-write</access>
             </field>
           </fields>
@@ -9074,6 +9053,7 @@
           <description>CSP Z data register</description>
           <addressOffset>0x190</addressOffset>
           <size>32</size>
+          <access>read-only</access>
           <resetValue>0</resetValue>
           <fields>
             <field>

--- a/tests/periph_macros.rs
+++ b/tests/periph_macros.rs
@@ -93,4 +93,14 @@ fn periph_macros1() {
     {
         let sysctrl = drone_tisl_map::periph::sysctrl::periph_sysctrl!(reg);
     }
+    #[cfg(all(
+        feature = "radio",
+        any(
+            tisl_mcu = "cc2538",
+        )
+    ))]
+    {
+        let radio = drone_tisl_map::periph::radio::periph_radio!(reg);
+    }
+
 }


### PR DESCRIPTION
The RF Core has multiple modules:
- [x] RFCORE_FFSM registers
- [x] RFCORE_XREG registers
- [ ] RFCORE_SFR registers
- [ ] CCTEST registers
- [ ] ANA_REGS registers